### PR TITLE
templates: facets year fix

### DIFF
--- a/dist/templates/conferences/facets.html
+++ b/dist/templates/conferences/facets.html
@@ -7,7 +7,7 @@
           <label>
             <input class="include-facet" type="checkbox" ng-checked="handler[key].indexOf(item.key) > -1" ng-click="handleClick(key, item.key)" />
             <span ng-if="key != 'opening_date'" class="facet-title-truncate">{{ item.key | capitalize }}</span>
-            <span ng-if="key == 'opening_date'" class="facet-title-truncate">{{ item.key | date:'yyyy' }}</span>
+            <span ng-if="key == 'opening_date'" class="facet-title-truncate">{{ item.key_as_string }}</span>
             <span class="facet-label label label-default pull-right">{{ item.doc_count }}</span>
           </label>
         </li>

--- a/dist/templates/literature/facets.html
+++ b/dist/templates/literature/facets.html
@@ -7,7 +7,7 @@
           <label>
             <input class="include-facet" type="checkbox" ng-checked="handler[key].indexOf(item.key) > -1" ng-click="handleClick(key, item.key)" />
             <span ng-if="key != 'earliest_date'" class="facet-title-truncate">{{ item.key | capitalize }}</span>
-            <span ng-if="key == 'earliest_date'" class="facet-title-truncate">{{ item.key | date:'yyyy' }}</span>
+            <span ng-if="key == 'earliest_date'" class="facet-title-truncate">{{ item.key_as_string }}</span>
             <span class="facet-label label label-default pull-right">{{ item.doc_count }}</span>
           </label>
         </li>

--- a/src/inspirehep-search-js/templates/conferences/facets.html
+++ b/src/inspirehep-search-js/templates/conferences/facets.html
@@ -7,7 +7,7 @@
           <label>
             <input class="include-facet" type="checkbox" ng-checked="handler[key].indexOf(item.key) > -1" ng-click="handleClick(key, item.key)" />
             <span ng-if="key != 'opening_date'" class="facet-title-truncate">{{ item.key | capitalize }}</span>
-            <span ng-if="key == 'opening_date'" class="facet-title-truncate">{{ item.key | date:'yyyy' }}</span>
+            <span ng-if="key == 'opening_date'" class="facet-title-truncate">{{ item.key_as_string }}</span>
             <span class="facet-label label label-default pull-right">{{ item.doc_count }}</span>
           </label>
         </li>

--- a/src/inspirehep-search-js/templates/literature/facets.html
+++ b/src/inspirehep-search-js/templates/literature/facets.html
@@ -7,7 +7,7 @@
           <label>
             <input class="include-facet" type="checkbox" ng-checked="handler[key].indexOf(item.key) > -1" ng-click="handleClick(key, item.key)" />
             <span ng-if="key != 'earliest_date'" class="facet-title-truncate">{{ item.key | capitalize }}</span>
-            <span ng-if="key == 'earliest_date'" class="facet-title-truncate">{{ item.key | date:'yyyy' }}</span>
+            <span ng-if="key == 'earliest_date'" class="facet-title-truncate">{{ item.key_as_string }}</span>
             <span class="facet-label label label-default pull-right">{{ item.doc_count }}</span>
           </label>
         </li>


### PR DESCRIPTION
- Uses key_as_string for date histograms to show the year string.

Signed-off-by: Javier Martin Montull javier.martin.montull@cern.ch
