### PR TITLE
use $templateCache for production

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "coveralls": "^2.11.4",
     "del": "^2.1.0",
     "gulp": "^3.8.7",
+    "gulp-angular-templatecache": "^2.0.0",
     "gulp-concat": "^2.3.4",
     "gulp-coveralls": "^0.1.4",
     "gulp-flatten": "^0.3.1",

--- a/src/inspirehep-search-js/inspirehepSearch.module.js
+++ b/src/inspirehep-search-js/inspirehepSearch.module.js
@@ -30,6 +30,7 @@
     'inspirehepExport',
     'inspirehepPermissions',
     'inspirehepSearch.filters',
+    'inspirehepSearchTemplates',
     'ui.bootstrap',
     'authors'
   ]);


### PR DESCRIPTION
* Makes sure when a new version of the JavaScript code is deployed
  the users will not need a hard refresh.

* It also avoids doing requests to the server for templates in production.

Signed-off-by: Javier Martin Montull <javier.martin.montull@cern.ch>