### PR TITLE
template: add html to assist with the ui changes

### DIFF
--- a/src/inspirehep-holdingpen-js/templates/inspirehep-holdingpen-js/facets.html
+++ b/src/inspirehep-holdingpen-js/templates/inspirehep-holdingpen-js/facets.html
@@ -7,7 +7,7 @@
     <ul class="list-unstyled" class="hp-facet-item">
       <li
         ng-repeat="item in vm.invenioSearchResults.aggregations[key].buckets | limitTo: facetResults"
-        ng-click="handleClick(key, item.key)">
+        ng-click="handleClick(key, item.key)" class="clearfix">
         <span class="facet-title-truncate">
           <i class="fa fa-times" ng-if="handler[key].indexOf(item.key) > -1"></i>
           <span ng-switch="item.key">

--- a/src/inspirehep-holdingpen-js/templates/inspirehep-holdingpen-js/results/results.html
+++ b/src/inspirehep-holdingpen-js/templates/inspirehep-holdingpen-js/results/results.html
@@ -68,8 +68,7 @@
              ng-class="record._source._workflow.workflow_class"
              ng-bind="record._source.metadata.acquisition_source.source"></p>
           <p ng-bind="record._source.metadata.acquisition_source.email"></p>
-          <p
-            ng-bind="record._source._workflow.created | date: ''"></p>
+          <p ng-if="record._source._workflow.created" ng-bind="record._source._workflow.created | date: ''"></p>
         </div>
 
         <div class="col-md-2 pad-top-10">


### PR DESCRIPTION
In combination with [PR #2914](https://github.com/inspirehep/inspire-next/pull/2914) in inspre-next this PR adds a helper class to the facets label to help with their correct positioning and it inserts the date field only if it is present in the record

Signed-off-by: Dinika <dinika.saxena@cern.ch>