### PR TITLE
test: update test to not fait on the 26th of a month

### DIFF
--- a/test/unit/filters/filterDeadlinePassedSpec.js
+++ b/test/unit/filters/filterDeadlinePassedSpec.js
@@ -35,9 +35,7 @@ describe('Test Deadline Passed filter', function () {
 
             someDate.setDate(someDate.getDate() + numberOfDaysToAdd);
 
-            var dd = someDate.getDate() === 26 ?
-                    ("0" + someDate.getDate() + 1).slice(-2) : 
-                    ("0" + someDate.getDate()).slice(-2),
+            var dd = ("0" + (someDate.getDate() )).slice(-2),
                 mm = ("0" + (someDate.getMonth() + 1)).slice(-2),
                 y = someDate.getFullYear();
             var date = y + '-' + mm + '-' + dd;


### PR DESCRIPTION
The test was earlier failing on the 26th of a month because after the calculations the code was converting 26 to 32 which is an invalid date. 
 
Signed-off-by: Dinika <dinika.saxena@cern.ch>