### PR TITLE
holdingpen: modify Reject button for fully covered journals

### DIFF
--- a/src/inspirehep-holdingpen-js/templates/inspirehep-holdingpen-js/details/details_decision_hep.html
+++ b/src/inspirehep-holdingpen-js/templates/inspirehep-holdingpen-js/details/details_decision_hep.html
@@ -15,12 +15,15 @@
   </button>
 
   <button ng-if="vm.record.metadata.acquisition_source.method == 'submitter'"
-          class="btn btn-danger"
-          ng-click="Utils.setRejectionReason()">Reject
+          ng-class="{'btn btn-danger': vm.record._extra_data.journal_coverage == 'partial',
+          'btn btn-danger-weak': vm.record._extra_data.journal_coverage == 'full'}"
+          ng-click="Utils.setRejectionReason()"
+          uib-tooltip="The article belongs to a fully taken journal">Reject
   </button>
   <button ng-if="vm.record.metadata.acquisition_source.method == 'hepcrawl'"
           class="btn btn-danger"
-          ng-click="Utils.setDecision('reject')">Reject
+          ng-click="Utils.setDecision('reject')"
+          uib-tooltip="The article belongs to a fully taken journal">Reject
   </button>
 </div>
 

--- a/src/inspirehep-holdingpen-js/templates/inspirehep-holdingpen-js/results/results.html
+++ b/src/inspirehep-holdingpen-js/templates/inspirehep-holdingpen-js/results/results.html
@@ -114,12 +114,16 @@
                         ng-click="setDecision(record._id,'accept')">Accept
                 </button>
                 <button ng-if="record._source.metadata.acquisition_source.method == 'hepcrawl'"
-                        class="btn btn-danger"
-                        ng-click="setDecision(record._id, 'reject')">Reject
+                        ng-class="{'btn btn-danger': record._source._extra_data.journal_coverage == 'partial',
+                                   'btn btn-danger-weak': record._source._extra_data.journal_coverage == 'full'}"
+                        ng-click="redirect('/holdingpen/' + record._id)"
+                        uib-tooltip="The article belongs to a fully taken journal">Reject
                 </button>
                 <button ng-if="record._source.metadata.acquisition_source.method == 'submitter'"
-                        class="btn btn-danger"
-                        ng-click="redirect('/holdingpen/' + record._id)">Reject
+                        ng-class="{'btn btn-danger':record._source._extra_data.journal_coverage == 'partial',
+                                   'btn btn-danger-weak':record._source._extra_data.journal_coverage == 'full'}"
+                        ng-click="redirect('/holdingpen/' + record._id)"
+                        uib-tooltip="The article belongs to a fully taken journal">Reject
                 </button>
               </div>
             </div>


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
New requirements say that the Reject button - in both the holdingpen list and detailed view - should have 0.3 opacity, no border and a tooltip saying 'The article belongs to a fully taken journal' when the article is  part of a fully covered journal in INSPIRE, thus the probability of its being rejected is small.

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/inspirehep/inspire-next/issues/2643

## Related PR
This is linked to this SCSS change:
https://github.com/inspirehep/inspire-next/pull/2919

Signed-off-by: Iuliana Voinea <iuliana.voinea@student.manchester.ac.uk>