### PR TITLE
save changes before redirecting to the editor

### DIFF
--- a/src/inspirehep-holdingpen-js/holdingpen/holdingpen.directives.js
+++ b/src/inspirehep-holdingpen-js/holdingpen/holdingpen.directives.js
@@ -270,6 +270,11 @@
             $window.location = url;
           },
 
+          saveAndRedirect: function(url) {
+            HoldingPenRecordService.updateRecord($scope.vm, $scope.workflowId)
+            .then($window.location = url);
+          },
+
           addSubjectArea: function () {
             function _subjectAlreadyPresent(subject) {
               for (var i = 0; i < $scope.vm.record.metadata.inspire_categories.length; i++) {

--- a/src/inspirehep-holdingpen-js/templates/inspirehep-holdingpen-js/details/details.html
+++ b/src/inspirehep-holdingpen-js/templates/inspirehep-holdingpen-js/details/details.html
@@ -433,7 +433,7 @@
             </button>
             <button class="btn btn-info"
                     ng-if="vm.record._workflow.status === 'HALTED'"
-                    ng-click="Utils.redirect('/editor/holdingpen/' + vm.record.id)">
+                    ng-click="Utils.saveAndRedirect('/editor/holdingpen/' + vm.record.id)">
               <i class="fa fa-pencil" aria-hidden="true"></i> Open in Editor
             </button>
             <button class="btn btn-default"


### PR DESCRIPTION
Pressing the 'Open in Editor' button will now save the changes made in holdingpen before redirecting the user to the editor

closes inspirehep/inspire-next/issues/2493
Signed-off-by: Dinika <dinika.saxena@cern.ch>