### PR TITLE
templates: improve selection of sort options

### DIFF
--- a/src/inspirehep-search-js/templates/selectbox.html
+++ b/src/inspirehep-search-js/templates/selectbox.html
@@ -1,5 +1,6 @@
-<select name="select-{{ data.sortParameter }}" class="form-control" ng-model="data.selectedOption" ng-change="handleFieldChange()">
-  <option ng-repeat="option in data.availableOptions.options"
-   value="{{ option.value }}"
-   ng-selected="isSelected(option.value)">{{ option.title }}</option>
+<select name="select-{{ data.sortParameter }}" 
+		class="form-control" 
+		ng-options="option.value as option.title for option in data.availableOptions.options track by option.value"
+		ng-model="data.selectedOption"
+		ng-change="handleFieldChange()">
 </select>


### PR DESCRIPTION
Angular r[ecommends the use of ng-options](https://docs.angularjs.org/api/ng/directive/ngOptions) over ng-repeat, since the former reduces memory consumption and increases render speed. 
 
Signed-off-by: Dinika <dinika.saxena@cern.ch>