### PR TITLE
Fix 'Reject' buttons to reflect the journal coverage.

### DIFF
--- a/src/inspirehep-holdingpen-js/holdingpen/holdingpen.controllers.js
+++ b/src/inspirehep-holdingpen-js/holdingpen/holdingpen.controllers.js
@@ -78,7 +78,8 @@
       HoldingPenRecordService.setBatchDecision($scope.vm.invenioSearchResults.hits.hits, [+id], decision);
     }
     function hasConflicts(record) {
-      return record._source._extra_data.conflicts !== undefined && record._source._extra_data.conflicts.length > 0;
+      var _extra_data =  record._source._extra_data;
+      return _extra_data && _extra_data.conflicts !== undefined && _extra_data.conflicts.length > 0;
     }
     function toggleAll() {
       var remove_all = allChecked();

--- a/src/inspirehep-holdingpen-js/templates/inspirehep-holdingpen-js/details/details_decision_hep.html
+++ b/src/inspirehep-holdingpen-js/templates/inspirehep-holdingpen-js/details/details_decision_hep.html
@@ -14,16 +14,25 @@
           ng-click="Utils.setDecision('accept')">Accept
   </button>
 
-  <button ng-if="vm.record.metadata.acquisition_source.method == 'submitter'"
-          ng-class="{'btn btn-danger': vm.record._extra_data.journal_coverage == 'partial',
-          'btn btn-danger-weak': vm.record._extra_data.journal_coverage == 'full'}"
+  <button ng-if="vm.record.metadata.acquisition_source.method == 'submitter' && vm.record._extra_data.journal_coverage == 'full'"
+          class="btn btn-danger-weak"
           ng-click="Utils.setRejectionReason()"
           uib-tooltip="The article belongs to a fully taken journal">Reject
   </button>
-  <button ng-if="vm.record.metadata.acquisition_source.method == 'hepcrawl'"
-          class="btn btn-danger"
+    <button ng-if="vm.record.metadata.acquisition_source.method == 'submitter'
+                   && (!vm.record._extra_data.journal_coverage || vm.record._extra_data.journal_coverage == 'partial')"
+            class="btn btn-danger"
+            ng-click="Utils.setRejectionReason()">Reject
+  </button>
+    <button ng-if="vm.record.metadata.acquisition_source.method == 'hepcrawl' && vm.record._extra_data.journal_coverage == 'full'"
+          class="btn btn-danger-weak"
           ng-click="Utils.setDecision('reject')"
           uib-tooltip="The article belongs to a fully taken journal">Reject
+  </button>
+  <button ng-if="vm.record.metadata.acquisition_source.method == 'hepcrawl'
+                 && (!vm.record._extra_data.journal_coverage || vm.record._extra_data.journal_coverage == 'partial')"
+          class="btn btn-danger"
+          ng-click="Utils.setDecision('reject')">Reject
   </button>
 </div>
 

--- a/src/inspirehep-holdingpen-js/templates/inspirehep-holdingpen-js/results/results.html
+++ b/src/inspirehep-holdingpen-js/templates/inspirehep-holdingpen-js/results/results.html
@@ -112,17 +112,25 @@
                 <button class="btn btn-warning"
                         ng-click="setDecision(record._id,'accept')">Accept
                 </button>
-                <button ng-if="record._source.metadata.acquisition_source.method == 'hepcrawl'"
-                        ng-class="{'btn btn-danger': record._source._extra_data.journal_coverage == 'partial',
-                                   'btn btn-danger-weak': record._source._extra_data.journal_coverage == 'full'}"
+                <button ng-if="record._source.metadata.acquisition_source.method == 'hepcrawl' && record._source._extra_data.journal_coverage == 'full'"
+                        class="btn btn-danger-weak"
                         ng-click="redirect('/holdingpen/' + record._id)"
                         uib-tooltip="The article belongs to a fully taken journal">Reject
                 </button>
-                <button ng-if="record._source.metadata.acquisition_source.method == 'submitter'"
-                        ng-class="{'btn btn-danger':record._source._extra_data.journal_coverage == 'partial',
-                                   'btn btn-danger-weak':record._source._extra_data.journal_coverage == 'full'}"
+                  <button ng-if="record._source.metadata.acquisition_source.method == 'hepcrawl'
+                                 && (!record._source._extra_data.journal_coverage || record._source._extra_data.journal_coverage == 'partial')"
+                        class="btn btn-danger"
+                        ng-click="redirect('/holdingpen/' + record._id)">Reject
+                </button>
+                <button ng-if="record._source.metadata.acquisition_source.method == 'submitter' && record._source._extra_data.journal_coverage == 'full'"
+                        class="btn btn-danger-weak"
                         ng-click="redirect('/holdingpen/' + record._id)"
                         uib-tooltip="The article belongs to a fully taken journal">Reject
+                </button>
+                  <button ng-if="record._source.metadata.acquisition_source.method == 'submitter'
+                                 && (!record._source._extra_data.journal_coverage || record._source._extra_data.journal_coverage == 'partial')"
+                        class="btn btn-danger"
+                        ng-click="redirect('/holdingpen/' + record._id)">Reject
                 </button>
               </div>
             </div>


### PR DESCRIPTION
I fixed the `Reject` buttons for both the list and detail views in holdingpen. Now, they are displayed properly even if the workflow object does not contain in `_extra_data` the required `journal_coverage` field which sometimes is the case. This previously broke the button. 

Moreover, I introduced a small change in the holdingpen angular controller that allows decision buttons to be displayed even if there is no `_extra_data`. Before this, the `hasConflicts` controller function did not allow the decision buttons to be displayed if `_extra_data` was undefined.

Signed-off-by: Iuliana Voinea <iuliana.voinea@student.manchester.ac.uk>