### PR TITLE
templates: fix possible matches UI for pub_info & abstract

### DIFF
--- a/src/inspirehep-holdingpen-js/templates/inspirehep-holdingpen-js/details/details.html
+++ b/src/inspirehep-holdingpen-js/templates/inspirehep-holdingpen-js/details/details.html
@@ -65,9 +65,6 @@
           <div ng-if="vm.record._workflow.data_type === 'hep'">
             <h4 class="record-title" ng-bind-html="vm.record.metadata.titles[0].title" editable-text="vm.record.metadata.titles[0].title"
               e-ng-change="Utils.registerUpdateEvent()"></h4>
-            <div ng-if="vm.record.metadata.publication_info" class="text-bolder">
-              <p class="text-muted">{{vm.record.metadata.publication_info[0].journal_title}}, {{vm.record.metadata.publication_info[0].year}}</p>
-            </div>
 
             <ul class="record-authors">
               {{ limit = 10; ""}}
@@ -78,10 +75,25 @@
               </li>
               <li ng-if="vm.record.metadata.authors.length > limit">et al.
               </li>
-              ({{vm.record.metadata.authors.length}} Authors)
+              <span ng-if="vm.record.metadata.authors.length > 1">({{vm.record.metadata.authors.length}} authors)</span>
             </ul>
 
-
+            <div ng-if="vm.record.metadata.publication_info && vm.record.metadata.publication_info[0]" class="record-pub-info">
+              <span ng-if="vm.record.metadata.publication_info[0].journal_title || vm.record.metadata.publication_info[0].pubinfo_freetext" class="text-bolder">Published In: </span>
+              <span ng-if="vm.record.metadata.publication_info[0].journal_title">
+                {{vm.record.metadata.publication_info[0].journal_title}}
+                <span ng-if="vm.record.metadata.publication_info[0].journal_volume"> {{vm.record.metadata.publication_info[0].journal_volume}}</span>
+                <span ng-if="vm.record.metadata.publication_info[0].year"> ({{vm.record.metadata.publication_info[0].year}})</span>
+                <span ng-if="vm.record.metadata.publication_info[0].journal_issue"> {{vm.record.metadata.publication_info[0].journal_issue}}</span>  
+                <span ng-if="vm.record.metadata.publication_info[0].page_start && vm.record.metadata.publication_info[0].page_end">
+                  {{vm.record.metadata.publication_info[0].page_start}}
+                  <span ng-if="vm.record.metadata.publication_info[0].page_end">-{{vm.record.metadata.publication_info[0].page_end}}</span>
+                </span>
+                <span ng-if="vm.record.metadata.publication_info[0].artid">, {{vm.record.metadata.publication_info[0].artid}}</span>
+              </span>
+              <span ng-if="!vm.record.metadata.publication_info[0].journal_title && vm.record.metadata.publication_info[0].pubinfo_freetext">{{vm.record.metadata.publication_info[0].pubinfo_freetext}}</span>
+            </div>
+              
             <p class="record-abstract" ng-bind-html="vm.record.metadata.abstracts[0].value" editable-textarea="vm.record.metadata.abstracts[0].value"
               e-ng-change="Utils.registerUpdateEvent()">
             </p>
@@ -296,17 +308,24 @@
                   <div class="panel-body matches">
                     <div ng-if="match.authors" class="authors">
                       <span ng-repeat="author in match.authors">{{author.full_name}} <span ng-if="!$last"> ; </span></span>
-                      ({{vm.record.metadata.authors.length}} Authors)
+                      <span ng-if="match.authors_count > 1">({{match.authors_count}} authors)</span>
                     </div>
                     <dl class="dl-horizontal">
-                      <dt ng-if="match.publication_info">Published In</dt>
+                      <dt ng-if="match.publication_info && match.publication_info[0] && (match.publication_info[0].journal_title || match.publication_info[0].pubinfo_freetext) ">Published In</dt>
                       <dd>
                         <span ng-repeat="pub_info in match.publication_info">
-                          <span ng-if="pub_info.journal_title">{{pub_info.journal_title}}</span>
-                          <span ng-if="pub_info.journal_volume">{{pub_info.journal_volume}}</span>
-                          <span ng-if="pub_info.year">({{pub_info.year}})</span>
-                          <span ng-if="pub_info.journal_issue"> {{pub_info.journal_issue}}</span>
-                          <span ng-if="pub_info.artid">, {{pub_info.artid}}</span>  
+                          <span ng-if="pub_info.journal_title">
+                            {{pub_info.journal_title}}
+                            <span ng-if="pub_info.journal_volume"> {{pub_info.journal_volume}}</span>
+                            <span ng-if="pub_info.year"> ({{pub_info.year}})</span>
+                            <span ng-if="pub_info.journal_issue"> {{pub_info.journal_issue}}</span>  
+                            <span ng-if="pub_info.page_start && pub_info.page_end">
+                              {{pub_info.page_start}}
+                              <span ng-if="pub_info.page_end">-{{pub_info.page_end}}</span>
+                            </span>
+                            <span ng-if="pub_info.artid">, {{pub_info.artid}}</span>
+                          </span>
+                          <span ng-if="!pub_info.journal_title && pub_info.pubinfo_freetext">{{pub_info.pubinfo_freetext}}</span>
                           <span ng-if="!$last"> ; </span>
                         </span>
                       </dd>
@@ -322,15 +341,14 @@
 
                       <dt ng-if="match.public_notes">Public notes</dt>
                       <dd>
-                        <span ng-if="match.public_notes.length === 1">{{match.public_notes[0].value}}</span>
-                        <ul ng-if="match.public_notes.length > 1">
+                        <ul ng-if="match.public_notes">
                           <li ng-repeat="public_note in match.public_notes">{{public_note.value}}</li>
                         </ul>
                       </dd>
                     </dl>
-                    <div ng-init="showAbstract=false">
+                    <div ng-init="showAbstract=false" ng-if="match.abstract">
                       <a href="" ng-click='showAbstract=!showAbstract'>{{ showAbstract ? 'Hide abstract' : 'Show abstract'}}</a>
-                      <p ng-if="match.abstract && showAbstract">{{match.abstract}}</p>
+                      <p ng-if="showAbstract">{{match.abstract}}</p>
                     </div> 
                   </div>   
                 </div>

--- a/src/inspirehep-holdingpen-js/templates/inspirehep-holdingpen-js/results/results.html
+++ b/src/inspirehep-holdingpen-js/templates/inspirehep-holdingpen-js/results/results.html
@@ -223,19 +223,26 @@
                         <div class="panel-body">
                           <div ng-if="match.authors" class="authors">
                             <span ng-repeat="author in match.authors">{{author.full_name}} <span ng-if="!$last"> ; </span> </span>
-                            <span ng-if="match.authors_count">({{match.authors_count}} Authors)</span>
+                            <span ng-if="match.authors_count > 1">({{match.authors_count}} authors)</span>
                           </div>
 
                           <dl class="dl-horizontal">
 
-                            <dt ng-if="match.publication_info">Published In</dt>
+                            <dt ng-if="match.publication_info && match.publication_info[0] && (match.publication_info[0].journal_title || match.publication_info[0].pubinfo_freetext) ">Published In</dt>
                             <dd>
                               <span ng-repeat="pub_info in match.publication_info">
-                                <span ng-if="pub_info.journal_title">{{pub_info.journal_title}}</span>
-                                <span ng-if="pub_info.journal_volume">{{pub_info.journal_volume}}</span>
-                                <span ng-if="pub_info.year">({{pub_info.year}})</span>
-                                <span ng-if="pub_info.journal_issue"> {{pub_info.journal_issue}}</span>
-                                <span ng-if="pub_info.artid">, {{pub_info.artid}}</span>  
+                                <span ng-if="pub_info.journal_title">
+                                  {{pub_info.journal_title}}
+                                  <span ng-if="pub_info.journal_volume"> {{pub_info.journal_volume}}</span>
+                                  <span ng-if="pub_info.year"> ({{pub_info.year}})</span>
+                                  <span ng-if="pub_info.journal_issue"> {{pub_info.journal_issue}}</span>  
+                                  <span ng-if="pub_info.page_start && pub_info.page_end">
+                                    {{pub_info.page_start}}
+                                    <span ng-if="pub_info.page_end">-{{pub_info.page_end}}</span>
+                                  </span>
+                                  <span ng-if="pub_info.artid">, {{pub_info.artid}}</span>
+                                </span>
+                                <span ng-if="!pub_info.journal_title && pub_info.pubinfo_freetext">{{pub_info.pubinfo_freetext}}</span>
                                 <span ng-if="!$last"> ; </span>
                               </span>
                             </dd>
@@ -251,16 +258,15 @@
 
                             <dt ng-if="match.public_notes">Public notes</dt>
                             <dd>
-                              <span ng-if="match.public_notes.length === 1">{{match.public_notes[0].value}}</span>
-                              <ul ng-if="match.public_notes.length > 1">
+                              <ul ng-if="match.public_notes">
                                 <li ng-repeat="public_note in match.public_notes">{{public_note.value}}</li>
                               </ul>
                             </dd>
                           </dl>
                             
-                          <div ng-init="showAbstract=false">
+                          <div ng-init="showAbstract=false" ng-if="match.abstract">
                             <a href="" ng-click='showAbstract=!showAbstract'>{{ showAbstract ? 'Hide abstract' : 'Show abstract'}}</a>
-                            <p ng-if="match.abstract && showAbstract">{{match.abstract}}</p>
+                            <p ng-if="showAbstract">{{match.abstract}}</p>
                           </div>
                         </div>
                     </div>

--- a/src/inspirehep-holdingpen-js/templates/inspirehep-holdingpen-js/results/results_details_hep.html
+++ b/src/inspirehep-holdingpen-js/templates/inspirehep-holdingpen-js/results/results_details_hep.html
@@ -18,44 +18,50 @@
 
 <h4 class="custom-h">
 
-  <a class="title" ng-if="record._source.metadata.titles && !hasCrawlErrors(record)" ng-href="/holdingpen/{{record._id}}" ng-bind-html='record._source.metadata.titles[0].title'></a>
-  <a class="title" ng-if="hasCrawlErrors(record)" ng-href="/holdingpen/{{record._id}}">
+   <a class="title" ng-if="record._source.metadata.titles && !hasCrawlErrors(record)" ng-href="/holdingpen/{{record._id}}" ng-bind-html='record._source.metadata.titles[0].title'></a>
+   <a class="title" ng-if="hasCrawlErrors(record)" ng-href="/holdingpen/{{record._id}}">
     {{record._source._extra_data.crawl_errors.file_name}}
   </a>
 </h4>
 
 <div class="authors" ng-if="record._source.metadata.authors">
-  <span ng-repeat="author in record._source.metadata.authors | limitTo:10">
-    {{author.full_name}}
-    <span ng-if="!$last">; </span>
-    <span ng-if="$last && record._source.metadata.authors.length > 10">; et al. </span>
-  </span>({{ record._source.metadata.authors.length }} Authors)
+    <span ng-repeat="author in record._source.metadata.authors | limitTo:10">
+      {{author.full_name}}<span ng-if="!$last">; </span><span
+      ng-if="$last && record._source.metadata.authors.length > 10">; et al. </span>
+    </span>
+    <span ng-if="record._source.metadata.authors.length > 1">({{ record._source.metadata.authors.length }} authors)</span>
 </div>
 
-<dl class="dl-horizontal">
+  <dl class="dl-horizontal">
 
-  <dt ng-if="record._source.metadata.publication_info">Published In</dt>
-  <dd>
-    <span class="regular-text" ng-repeat="pub_info in record._source.metadata.publication_info">
-      <span ng-if="pub_info.journal_title">{{pub_info.journal_title}}</span>
-      <span ng-if="pub_info.journal_volume">{{pub_info.journal_volume}}</span>
-      <span ng-if="pub_info.year">({{pub_info.year}})</span>
-      <span ng-if="pub_info.journal_issue"> {{pub_info.journal_issue}}</span>
-      <span ng-if="pub_info.artid">, {{pub_info.artid}}</span>
-      <span ng-if="!$last"> ; </span>
-    </span>
-  </dd>
+    <dt ng-if="record._source.metadata.publication_info && record._source.metadata.publication_info[0] && (record._source.metadata.publication_info[0].journal_title || record._source.metadata.publication_info[0].pubinfo_freetext)">Published In</dt>
+    <dd>
+      <span ng-repeat="pub_info in record._source.metadata.publication_info">
+        <span ng-if="pub_info.journal_title">
+          {{pub_info.journal_title}}
+          <span ng-if="pub_info.journal_volume"> {{pub_info.journal_volume}}</span>
+          <span ng-if="pub_info.year"> ({{pub_info.year}})</span>
+          <span ng-if="pub_info.journal_issue"> {{pub_info.journal_issue}}</span>  
+          <span ng-if="pub_info.page_start && pub_info.page_end">
+            {{pub_info.page_start}}
+            <span ng-if="pub_info.page_end">-{{pub_info.page_end}}</span>
+          </span>
+          <span ng-if="pub_info.artid">, {{pub_info.artid}}</span>
+        </span>
+        <span ng-if="!pub_info.journal_title && pub_info.pubinfo_freetext">{{pub_info.pubinfo_freetext}}</span>
+        <span ng-if="!$last"> ; </span>
+      </span>
+    </dd>
 
-  <dt ng-if="record._source.metadata.number_of_pages">Number of Pages</dt>
-  <dd>{{record._source.metadata.number_of_pages}}</dd>
+    <dt ng-if="record._source.metadata.number_of_pages">Number of Pages</dt>
+    <dd>{{record._source.metadata.number_of_pages}}</dd>
 
-  <dt ng-if="record._source.metadata.public_notes">Public notes</dt>
-  <dd>
-    <span ng-if="record._source.metadata.public_notes.length === 1" class="regular-text">{{record._source.metadata.public_notes[0].value}}</span>
-    <ul ng-if="record._source.metadata.public_notes.length > 1">
-      <li ng-repeat="public_note in record._source.metadata.public_notes">{{public_note.value}}</li>
-    </ul>
-  </dd>
+    <dt ng-if="record._source.metadata.public_notes">Public notes</dt>
+    <dd>
+      <ul ng-if="record._source.metadata.public_notes" class="public-notes">
+        <li ng-repeat="public_note in record._source.metadata.public_notes">{{public_note.value}}</li>
+      </ul>
+    </dd>
 
 </dl>
 


### PR DESCRIPTION
User Story - [Inspire-435](https://its.cern.ch/jira/browse/INSPIR-435)
Following things were improved:

- the public_notes is always displayed as a list element (no bullet points though) even when there is only one public-note
- If there is one author, number of authors is not displayed. Same applies for the possible matches for a submitted record (also, `author` is changed to all small alphabets - just a small change)
- For records that do not have journal-title in publication_info, the pubinfo_freetext field is displayed to be consistent with the information displayed on [literature UI](https://github.com/inspirehep/inspire-next/blob/master/inspirehep/modules/theme/templates/inspirehep_theme/format/record/Publication_info.tpl) 

![screenshot from 2018-04-18 14-39-02](https://user-images.githubusercontent.com/11242410/38932590-f78a8a32-4316-11e8-86c5-e53c081d72d3.png)


Signed-off-by: Dinika Saxena <dinika.saxena@cern.ch>