### PR TITLE
templates: show number of core and matched records

### DIFF
--- a/src/inspirehep-holdingpen-js/templates/inspirehep-holdingpen-js/details/details_decision_hep.html
+++ b/src/inspirehep-holdingpen-js/templates/inspirehep-holdingpen-js/details/details_decision_hep.html
@@ -48,6 +48,12 @@
 
 <div class="clearfix"></div>
 <br/>
+<div ng-if="vm.record._extra_data.reference_count">
+  <p>References: <strong>{{vm.record._extra_data.reference_count.core}}/{{vm.record.metadata.references.length}}</strong> core,
+    <strong>{{vm.record._extra_data.reference_count.core + vm.record._extra_data.reference_count.non_core}}/{{vm.record.metadata.references.length}}</strong>
+    matched</p>
+</div>
+
 <div class="decision-keywords">
   <p>
     <p>

--- a/src/inspirehep-holdingpen-js/templates/inspirehep-holdingpen-js/results/results.html
+++ b/src/inspirehep-holdingpen-js/templates/inspirehep-holdingpen-js/results/results.html
@@ -135,6 +135,12 @@
             </div>
 
             <br/>
+            <div ng-if="record._source._extra_data.reference_count">
+              <p class="small-text">References: <strong>{{record._source._extra_data.reference_count.core}}/{{record._source.metadata.references.length}}</strong> core,
+                <strong>{{record._source._extra_data.reference_count.core + record._source._extra_data.reference_count.non_core}}/{{record._source.metadata.references.length}}</strong>
+                matched</p>
+            </div>
+
             <div
               ng-init="filteredKeywords = record._source._extra_data.classifier_results.complete_output['filtered_core_keywords'];
                 allKeywords = (record._source._extra_data.classifier_results.complete_output | unifyKeywords)"


### PR DESCRIPTION
User-story: [INSPIR-192](https://its.cern.ch/jira/browse/INSPIR-192)
Needs [PR 3488](https://github.com/inspirehep/inspire-next/pull/3488) in inspire-next

The new information is added in the search results as well as in the detailed view templates.

Search results:
![refe](https://user-images.githubusercontent.com/11242410/41538883-96eb9b32-730c-11e8-9794-00f59bb07a69.png)

Detailed View:
![referecnses 2](https://user-images.githubusercontent.com/11242410/41538893-9f508030-730c-11e8-8e5b-459d2b34fa0b.png)

Signed-off-by: Dinika Saxena <dinika.saxena@cern.ch>