### PR TITLE
DEMO: Halt gently to resolve DOI conflicts

### DIFF
--- a/src/inspirehep-holdingpen-js/templates/inspirehep-holdingpen-js/results/results.html
+++ b/src/inspirehep-holdingpen-js/templates/inspirehep-holdingpen-js/results/results.html
@@ -224,7 +224,7 @@
           <div ng-if="!matchDecisionMadeById[record._id]" ng-init="selectedBestMatchesById[record._id] = record._source._extra_data.matches.fuzzy[0].control_number">
                 <h5>MATCHES</h5>
                 <div class="matchingRecords panel-group" ng-repeat="match in record._source._extra_data.matches.fuzzy">
-                  <div class="panel panel-datatables">
+                  <div class="panel">
                     <div class="panel-heading">
                         <input id="radio-{{record._id}}-{{match.control_number}}" ng-model="selectedBestMatchesById[record._id]" name="possible-matches-{{record._id}}" type="radio" value="{{match.control_number}}">
                         <label for="radio-{{record._id}}-{{match.control_number}}" class="custom-control-description panel-title">

--- a/src/inspirehep-holdingpen-js/templates/inspirehep-holdingpen-js/results/results.html
+++ b/src/inspirehep-holdingpen-js/templates/inspirehep-holdingpen-js/results/results.html
@@ -217,10 +217,14 @@
       </div>
     </div>
       <div class="col-md-12 matches-container" ng-if="record._source._extra_data.matches.fuzzy && record._source._workflow.data_type === 'hep' && record._source._workflow.status === 'HALTED' && record._source._extra_data._action === 'match_approval'">
+          <div ng-if="record._source._extra_data.matches.exact" class="red-color">
+                <h3>DOI Conflicts</h3>
+                <span ng-repeat="ematch in record._source._extra_data.matches.exact">recid:{{ematch}} <span ng-if="!$last"> or </span> </span>
+          </div>
           <div ng-if="!matchDecisionMadeById[record._id]" ng-init="selectedBestMatchesById[record._id] = record._source._extra_data.matches.fuzzy[0].control_number">
                 <h5>MATCHES</h5>
                 <div class="matchingRecords panel-group" ng-repeat="match in record._source._extra_data.matches.fuzzy">
-                  <div class="panel">
+                  <div class="panel panel-datatables">
                     <div class="panel-heading">
                         <input id="radio-{{record._id}}-{{match.control_number}}" ng-model="selectedBestMatchesById[record._id]" name="possible-matches-{{record._id}}" type="radio" value="{{match.control_number}}">
                         <label for="radio-{{record._id}}-{{match.control_number}}" class="custom-control-description panel-title">


### PR DESCRIPTION
**untested!!**
Same code should be added to detailed view.

* minimal solution to halt gently in case of DOI conflicts
* in case of more than one exact match display 'DOI conflict' when halted to confirm fuzzy matches

## What I didn't manage in this DEMO:
* a link to the records on legacy would be nice
https://inspirehep.net/search?p=recid%3A1477591+or+recid%3A1496635&of=hb&action_search=Search
* and a link to BibMerge
https://inspirehep.net/record/merge/#recid1=1496635&recid2=1477591

## What it should do in the end: 
* halt if there is more than one exact match
* display 'DOI conflict' and the exactly matched records

Signed-off-by: Kirsten Sachs <kirsten.sachs@desy.de>

## Related Issue
https://github.com/inspirehep/inspire-next/issues/3586
